### PR TITLE
Use node 12 lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:12
 
 EXPOSE 3000
 WORKDIR /app

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,6 @@
+with import <nixpkgs> {};
+mkShell {
+  buildInputs = [
+    nodejs-12_x
+  ];
+}


### PR DESCRIPTION
Ensure we use the same NodeJS version both in the docker image and locally during development.